### PR TITLE
RDKV: RDKServices L1 Test with Valgrind failed dueto Signal 11 crash in Bluetooth plugin

### DIFF
--- a/RDKShell/CHANGELOG.md
+++ b/RDKShell/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this RDK Service will be documented in this file.
 
 * For more details, refer to [versioning](https://github.com/rdkcentral/rdkservices#versioning) section under Main README.
 
+## [1.6.4] - 2025-02-27
+### Fixed
+- Increase Hibernation delay to 30sec
 
 ## [1.6.3] - 2024-09-09
 ### Added

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -53,7 +53,7 @@
 
 #define API_VERSION_NUMBER_MAJOR 1
 #define API_VERSION_NUMBER_MINOR 6
-#define API_VERSION_NUMBER_PATCH 3
+#define API_VERSION_NUMBER_PATCH 4
 
 const string WPEFramework::Plugin::RDKShell::SERVICE_NAME = "org.rdk.RDKShell";
 //methods
@@ -218,8 +218,8 @@ std::condition_variable gHibernateBlockedCondVariable;
 #ifdef HIBERNATE_NATIVE_APPS_ON_SUSPENDED
 std::set<std::string> gLaunchedToSuspended;
 std::mutex gLaunchedToSuspendedMutex;
-#define HIBERNATION_DELAY_FOR_LAUNCHED_TO_SUSPENDED_MS  15000
-#define HIBERNATION_DELAY_FOR_RESUMED_TO_SUSPENDED_MS   5000
+#define HIBERNATION_DELAY_FOR_LAUNCHED_TO_SUSPENDED_MS  30000
+#define HIBERNATION_DELAY_FOR_RESUMED_TO_SUSPENDED_MS   30000
 #endif
 
 #define ANY_KEY 65536

--- a/RDKShell/RDKShell.cpp
+++ b/RDKShell/RDKShell.cpp
@@ -787,10 +787,34 @@ namespace WPEFramework {
                     gLaunchedToSuspendedMutex.lock();
                     bool l2s = (gLaunchedToSuspended.find(mCallSign) != gLaunchedToSuspended.end());
                     gLaunchedToSuspendedMutex.unlock();
+                    // Override default delay with values from RFC
                     uint32_t delay = HIBERNATION_DELAY_FOR_RESUMED_TO_SUSPENDED_MS;
                     if (l2s)
                     {
                         delay = HIBERNATION_DELAY_FOR_LAUNCHED_TO_SUSPENDED_MS;
+
+                        if (Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppHibernate.DelayInSecLaunchedToSuspended", param))
+                        {
+                            try
+                            {
+                                delay = std::stoi(param.value) * 1000;
+                            }
+                            catch (...)
+                            {
+                                std::cout << "RDKShell unable to get AppHibernate.DelayInSecLaunchedToSuspended value " << std::endl;
+                            }
+                        }
+                    }
+                    else if (Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.Feature.AppHibernate.DelayInSecResumedToSuspended", param))
+                    {
+                        try
+                        {
+                            delay = std::stoi(param.value) * 1000;
+                        }
+                        catch (...)
+                        {
+                            std::cout << "RDKShell unable to get AppHibernate.DelayInSecResumedToSuspended value " << std::endl;
+                        }
                     }
 
                     if (mCallSign.find("Netflix") != std::string::npos || mCallSign.find("Cobalt") != std::string::npos)

--- a/TextToSpeech/CMakeLists.txt
+++ b/TextToSpeech/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(${MODULE_NAME} SHARED
         impl/TTSURLConstructer.cpp
         impl/NetworkStatusObserver.cpp
         impl/SatToken.cpp
+        impl/RFCURLObserver.cpp
         )
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11

--- a/TextToSpeech/TextToSpeechImplementation.cpp
+++ b/TextToSpeech/TextToSpeechImplementation.cpp
@@ -23,6 +23,7 @@
 #include <mutex>
 
 #include "TextToSpeechValidator.h"
+#include "impl/RFCURLObserver.h"
 
 #define TTS_MAJOR_VERSION 1
 #define TTS_MINOR_VERSION 0
@@ -38,6 +39,7 @@
 
 namespace WPEFramework {
 namespace Plugin {
+
 
     SERVICE_REGISTRATION(TextToSpeechImplementation, TTS_MAJOR_VERSION, TTS_MINOR_VERSION);
 
@@ -77,12 +79,13 @@ namespace Plugin {
         config.FromString(service->ConfigLine());
 
         TTS::TTSConfiguration *ttsConfig = _ttsManager->configuration();
+        TTS::RFCURLObserver::getInstance()->triggerRFC(ttsConfig);
         ttsConfig->setEndPoint(GET_STR(config, "endpoint", ""));
         ttsConfig->setSecureEndPoint(GET_STR(config, "secureendpoint", ""));
         ttsConfig->setLocalEndPoint(GET_STR(config, "localendpoint", ""));
         ttsConfig->setLanguage(GET_STR(config, "language", "en-US"));
         ttsConfig->setVoice(GET_STR(config, "voice", ""));
-        ttsConfig->setEndpointType(GET_STR(config, "endpoint_type", "TTS1"));
+        ttsConfig->setEndpointType(GET_STR(config, "endpoint_type", ""));
         ttsConfig->setSpeechRate(GET_STR(config, "speechrate", ""));
         ttsConfig->setVolume(std::stod(GET_STR(config, "volume", "100")));
         ttsConfig->setRate(std::stoi(GET_STR(config, "rate", "50")));
@@ -128,6 +131,7 @@ namespace Plugin {
         ttsConfig->loadFromConfigStore();
         TTSLOG_INFO("TTSEndPoint : %s", ttsConfig->endPoint().c_str());
         TTSLOG_INFO("SecureTTSEndPoint : %s", ttsConfig->secureEndPoint().c_str());
+        TTSLOG_INFO("RFCEndPoint : %s", ttsConfig->rfcEndPoint().c_str());
         TTSLOG_INFO("LocalTTSEndPoint : %s", ttsConfig->localEndPoint().c_str());
         TTSLOG_INFO("Language : %s", ttsConfig->language().c_str());
         TTSLOG_INFO("Voice : %s", ttsConfig->voice().c_str());
@@ -141,6 +145,15 @@ namespace Plugin {
         while( it != ttsConfig->m_others.end()) {
             TTSLOG_INFO("%s : %s", it->first.c_str(), it->second.c_str());
             ++it;
+        }
+        
+        if(ttsConfig->isRFCEnabled())
+        {
+            TTSLOG_INFO("TTS 2.0 Endpoint determined. URL:%s",ttsConfig->rfcEndPoint().c_str());
+        }
+        else
+        {
+            TTSLOG_INFO("TTS Endpoint URL is not determinable at boot time\n");
         }
 
         if(ttsConfig->hasValidLocalEndpoint()) {

--- a/TextToSpeech/TextToSpeechJsonRpc.cpp
+++ b/TextToSpeech/TextToSpeechJsonRpc.cpp
@@ -182,8 +182,12 @@ uint32_t TextToSpeech::SetACL(const JsonObject& parameters, JsonObject& response
             Exchange::ITextToSpeech::Configuration config;
             config.ttsEndPoint = GET_STR(parameters, "ttsendpoint", "");
             config.ttsEndPointSecured = GET_STR(parameters, "ttsendpointsecured", "");
-            config.language = GET_STR(parameters, "language", "");
+            config.language = GET_STR(parameters, "language", "");        
+            #ifndef UNIT_TESTING
+            config.voice = ""; //ignore voice from app           
+            #else
             config.voice = GET_STR(parameters, "voice", "");
+            #endif
             config.speechRate = GET_STR(parameters, "speechrate", "");
 
             std::string proxyVolume = GET_STR(parameters, "volume", "0.0");

--- a/TextToSpeech/impl/RFCURLObserver.cpp
+++ b/TextToSpeech/impl/RFCURLObserver.cpp
@@ -1,0 +1,148 @@
+#include <thread>
+#include "RFCURLObserver.h"
+#include "UtilsgetRFCConfig.h"
+#include "UtilsLogging.h"
+
+#if defined(SECURITY_TOKEN_ENABLED) && ((SECURITY_TOKEN_ENABLED == 0) || (SECURITY_TOKEN_ENABLED == false))
+#define GetSecurityToken(a, b) 0
+#define GetToken(a, b, c) 0
+#else
+#include <WPEFramework/securityagent/securityagent.h>
+#include <WPEFramework/securityagent/SecurityTokenUtil.h>
+#endif
+
+#define MAX_SECURITY_TOKEN_SIZE 1024
+#define SYSTEMSERVICE_CALLSIGN "org.rdk.System"
+#define SYSTEMSERVICE_CALLSIGN_VER SYSTEMSERVICE_CALLSIGN".1"
+
+#define MAX_RETRIES 3 // Define the maximum number of retries
+#define RETRY_DELAY_MS 2000 // Define the delay between retries in milliseconds
+
+using namespace WPEFramework;
+
+namespace TTS {
+
+RFCURLObserver* RFCURLObserver::getInstance() {
+    static RFCURLObserver *instance = new RFCURLObserver();
+    return instance;
+}
+
+
+void RFCURLObserver::triggerRFC(TTSConfiguration *config)
+{
+   m_defaultConfig = config;
+   fetchURLFromConfig();
+   std::thread notificationThread(&RFCURLObserver::registerNotification, this);
+   notificationThread.detach(); // Detach the thread to run independently
+}
+
+void RFCURLObserver::fetchURLFromConfig() {
+    bool  m_rfcURLSet = false;
+    RFC_ParamData_t param;
+    #ifndef UNIT_TESTING
+    m_rfcURLSet = Utils::getRFCConfig("Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.TextToSpeech.URL", param);
+    #endif
+    if (m_rfcURLSet) {
+	TTSLOG_INFO("Received RFC URL %s\n",param.value);
+        m_defaultConfig->setRFCEndPoint(param.value);
+    } else {
+        TTSLOG_ERROR("Error: Reading URL RFC failed.");
+    }
+}
+
+string RFCURLObserver::getSecurityToken() {
+    std::string token = "token=";
+    int tokenLength = 0;
+    unsigned char buffer[MAX_SECURITY_TOKEN_SIZE] = {0};
+    static std::string endpoint;
+
+    if(endpoint.empty()) {
+        Core::SystemInfo::GetEnvironment(_T("THUNDER_ACCESS"), endpoint);
+        TTSLOG_INFO("Thunder RPC Endpoint read from env - %s", endpoint.c_str());
+    }
+
+    if(endpoint.empty()) {
+        Core::File file("/etc/WPEFramework/config.json");
+        if(file.Open(true)) {
+            JsonObject config;
+            if(config.IElement::FromFile(file)) {
+                Core::JSON::String port = config.Get("port");
+                Core::JSON::String binding = config.Get("binding");
+                if(!binding.Value().empty() && !port.Value().empty())
+                    endpoint = binding.Value() + ":" + port.Value();
+            }
+            file.Close();
+        }
+        if(endpoint.empty()) 
+            endpoint = _T("127.0.0.1:9998");
+            
+        TTSLOG_INFO("Thunder RPC Endpoint read from config file - %s", endpoint.c_str());
+        Core::SystemInfo::SetEnvironment(_T("THUNDER_ACCESS"), endpoint);        
+    }
+
+    string payload = "http://localhost";
+    if(payload.empty()) {
+        tokenLength = GetSecurityToken(sizeof(buffer), buffer);
+    } else {
+        int buffLength = std::min(sizeof(buffer), payload.length());
+        ::memcpy(buffer, payload.c_str(), buffLength);
+        tokenLength = GetToken(sizeof(buffer), buffLength, buffer);
+    }
+
+    if(tokenLength > 0) {
+        token.append((char*)buffer);
+    } else {
+        token.clear();
+    }
+
+    TTSLOG_INFO("Thunder token - %s", token.empty() ? "" : token.c_str());
+    return token;
+}
+
+
+void RFCURLObserver::registerNotification() {
+    if (m_systemService == nullptr && !m_eventRegistered) {
+        std::string token = getSecurityToken();
+        if(token.empty()) {
+            m_systemService = new WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSTEMSERVICE_CALLSIGN_VER),"");
+        } else {        
+            m_systemService = new WPEFramework::JSONRPC::LinkType<Core::JSON::IElement>(_T(SYSTEMSERVICE_CALLSIGN_VER),"", false, token);
+        }
+
+	int retries = 0;
+        while (retries < MAX_RETRIES) {		
+            if (m_systemService->Subscribe<JsonObject>(3000, "onDeviceMgtUpdateReceived",
+                &RFCURLObserver::onDeviceMgtUpdateReceivedHandler, this) == Core::ERROR_NONE) {
+                m_eventRegistered = true;
+                TTSLOG_INFO("Subscribed to notification handler: onDeviceMgtUpdateReceived");
+                break;
+            } else {
+                TTSLOG_ERROR("Failed to subscribe to notification handler: onDeviceMgtUpdateReceived..Retrying");
+                std::this_thread::sleep_for(std::chrono::milliseconds(RETRY_DELAY_MS));
+                retries++;
+            }
+        }
+
+       if (!m_eventRegistered) {
+            TTSLOG_ERROR("Failed to subscribe to notification handler after maximum retries.");
+       }
+    }
+}
+
+void RFCURLObserver::onDeviceMgtUpdateReceivedHandler(const JsonObject& parameters) {
+    if(parameters["source"].String() == "rfc")
+    {
+       fetchURLFromConfig();
+       TTSLOG_INFO("onDeviceMgtUpdateReceived notification received");
+    }
+}
+
+RFCURLObserver::~RFCURLObserver() {
+   // Clean up resources
+    if (m_systemService) {
+        delete m_systemService;
+        m_systemService = nullptr;
+    }
+}
+
+}

--- a/TextToSpeech/impl/RFCURLObserver.h
+++ b/TextToSpeech/impl/RFCURLObserver.h
@@ -1,0 +1,31 @@
+#ifndef _TTS_RFC_H_
+#define _TTS_RFC_H_
+#include "TTSCommon.h"
+#include "TTSConfiguration.h"
+
+namespace TTS {
+
+class RFCURLObserver {
+public:
+    static RFCURLObserver* getInstance();
+    void triggerRFC(TTSConfiguration*);
+    ~RFCURLObserver();
+
+private:
+    RFCURLObserver(){};
+    RFCURLObserver(const RFCURLObserver&) = delete;
+    RFCURLObserver& operator=(const RFCURLObserver&) = delete;
+
+    void fetchURLFromConfig();
+    void registerNotification();
+    string getSecurityToken();
+	
+    void onDeviceMgtUpdateReceivedHandler(const JsonObject& parameters);
+
+    WPEFramework::JSONRPC::LinkType<WPEFramework::Core::JSON::IElement>* m_systemService{nullptr};
+    bool m_eventRegistered {false};
+    TTSConfiguration *m_defaultConfig;
+};
+
+}
+#endif

--- a/TextToSpeech/impl/TTSConfiguration.h
+++ b/TextToSpeech/impl/TTSConfiguration.h
@@ -21,6 +21,7 @@ public:
 
     bool setEndPoint(const std::string endpoint);
     bool setSecureEndPoint(const std::string endpoint);
+    bool setRFCEndPoint(const std::string endpoint);
     bool setApiKey(const std::string apikey);
     bool setEndpointType(const std::string type);
     bool setLocalEndPoint(const std::string endpoint);
@@ -35,6 +36,7 @@ public:
     bool setSATPluginCallsign(const std::string callsign);
    
     bool isFallbackEnabled();
+    bool isRFCEnabled();
     bool hasValidLocalEndpoint();
     void saveFallbackPath(std::string);
     const std::string getFallbackScenario();
@@ -47,10 +49,17 @@ public:
     const std::string &secureEndPoint() { return m_ttsEndPointSecured; }
     const std::string &localEndPoint() { return m_ttsEndPointLocal; }
     const std::string &apiKey() { return m_apiKey; }
-    const std::string &endPointType() { return m_endpointType; }
+    const std::string &endPointType() { 
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_endpointType; }
     const std::string &speechRate() { return m_speechRate; }
     const std::string &language() { return m_language; }
     const std::string &satPluginCallsign() { return m_satPluginCallsign; }
+    const std::string &rfcEndPoint() { 
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return  m_ttsRFCEndpoint; 
+    }
+
     const double &volume() { return m_volume; }
     const uint8_t &rate() { return m_rate; }
     const int8_t &primVolDuck() { return m_primVolDuck; }
@@ -71,6 +80,7 @@ private:
     std::string m_ttsEndPoint;
     std::string m_ttsEndPointSecured;
     std::string m_ttsEndPointLocal;
+    std::string m_ttsRFCEndpoint;
     std::string m_apiKey;
     std::string m_endpointType;
     std::string m_speechRate;
@@ -83,6 +93,7 @@ private:
     int8_t m_primVolDuck;
     bool m_preemptiveSpeaking;
     bool m_enabled;
+    bool m_ttsRFCEnabled;
     bool m_fallbackenabled;
     bool m_validLocalEndpoint;
     FallbackData m_data;

--- a/TextToSpeech/impl/TTSManager.cpp
+++ b/TextToSpeech/impl/TTSManager.cpp
@@ -288,7 +288,7 @@ TTS_Error TTSManager::getConfiguration(Configuration &configuration) {
     TTSLOG_TRACE("Getting Default Configuration");
 
     configuration.ttsEndPoint = m_defaultConfiguration.endPoint();
-    configuration.ttsEndPointSecured = m_defaultConfiguration.secureEndPoint();
+    configuration.ttsEndPointSecured = m_defaultConfiguration.isRFCEnabled() ? m_defaultConfiguration.rfcEndPoint() : m_defaultConfiguration.secureEndPoint();
     configuration.language = m_defaultConfiguration.language();
     configuration.voice = m_defaultConfiguration.voice();
     configuration.speechRate = m_defaultConfiguration.speechRate();

--- a/TextToSpeech/impl/TTSSpeaker.cpp
+++ b/TextToSpeech/impl/TTSSpeaker.cpp
@@ -48,6 +48,7 @@ TTSConfiguration::TTSConfiguration() :
     m_primVolDuck(25),
     m_preemptiveSpeaking(true),
     m_enabled(false),
+    m_ttsRFCEnabled(false),
     m_fallbackenabled(false),
     m_validLocalEndpoint(false) { }
 
@@ -69,6 +70,7 @@ TTSConfiguration::TTSConfiguration(TTSConfiguration &config)
     m_rate = config.m_rate;
     m_primVolDuck = config.m_primVolDuck;
     m_enabled = config.m_enabled;
+    m_ttsRFCEnabled = config.m_ttsRFCEnabled;
     m_validLocalEndpoint = config.m_validLocalEndpoint;
     m_preemptiveSpeaking = config.m_preemptiveSpeaking;
     m_data.scenario = config.m_data.scenario;
@@ -92,6 +94,7 @@ TTSConfiguration& TTSConfiguration::operator = (const TTSConfiguration &config)
     m_rate = config.m_rate;
     m_primVolDuck = config.m_primVolDuck;
     m_enabled = config.m_enabled;
+    m_ttsRFCEnabled =  config.m_ttsRFCEnabled;
     m_validLocalEndpoint = config.m_validLocalEndpoint;
     m_preemptiveSpeaking = config.m_preemptiveSpeaking;
     m_data.scenario = config.m_data.scenario;
@@ -119,6 +122,26 @@ bool TTSConfiguration::setSecureEndPoint(const std::string endpoint) {
     else
         TTSLOG_VERBOSE("Invalid Secured TTSEndPoint input \"%s\"", endpoint.c_str());
     return false;
+}
+
+bool TTSConfiguration::setRFCEndPoint(const std::string endpoint) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if(!endpoint.empty() && endpoint.find_first_not_of(' ') != std::string::npos) {
+        m_ttsRFCEnabled = true;
+        setEndpointType("TTS2");
+        UPDATE_AND_RETURN(m_ttsRFCEndpoint, endpoint);
+    } else {
+        m_ttsRFCEnabled = false;
+         if (!apiKey().empty()) {
+            setEndpointType("TTS1");
+        }
+        TTSLOG_VERBOSE("Invalid RFC TTSEndPoint input \"%s\"", endpoint.c_str());
+    }
+    return false;
+}
+
+bool TTSConfiguration::isRFCEnabled() {
+    return m_ttsRFCEnabled;
 }
 
 bool TTSConfiguration::setLocalEndPoint(const std::string endpoint) {

--- a/TextToSpeech/impl/TTSURLConstructer.cpp
+++ b/TextToSpeech/impl/TTSURLConstructer.cpp
@@ -27,7 +27,7 @@ TTSURLConstructer::~TTSURLConstructer() {
 }
 
 std::string TTSURLConstructer::constructURL(TTSConfiguration &config, std::string text, bool isFallback, bool isLocal) {
-    if(!(config.apiKey().empty()) && !isLocal) {
+    if(!(config.apiKey().empty()) && !isLocal && !(config.isRFCEnabled())) {
           TTSLOG_INFO("Device using remote sky endpoint");
           return httppostURL(config, text, isFallback);
      } else {
@@ -39,7 +39,7 @@ std::string TTSURLConstructer::constructURL(TTSConfiguration &config, std::strin
 std::string TTSURLConstructer::httpgetURL(TTSConfiguration &config, std::string text, bool isfallback, bool isLocal) {
     // EndPoint URL
     std::string ttsRequest;
-    ttsRequest.append(isLocal ? config.localEndPoint() : config.secureEndPoint());
+    ttsRequest.append(isLocal ? config.localEndPoint() : (config.isRFCEnabled() ? config.rfcEndPoint() : config.secureEndPoint()));
 
     // Voice
     if(!config.voice().empty()) {


### PR DESCRIPTION
Reason for change: To fix the crash because of some test functions in test_bluetooth.cpp
Test Procedure: Run the Gunit test cases.
Risks: Low
Priority: P1
Signed-off-by: Darshan Desale<darshan_desale@comcast.com>